### PR TITLE
Add no-array-from

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,18 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-				"ie11/no-collection-args": [ "error" ],
-				"ie11/no-for-in-const": [ "error" ],
-				"ie11/no-loop-func": [ "warn" ],
-				"ie11/no-weak-collections": [ "error" ]
+        "ie11/no-array-from": [ "error" ],
+        "ie11/no-collection-args": [ "error" ],
+        "ie11/no-for-in-const": [ "error" ],
+        "ie11/no-loop-func": [ "warn" ],
+        "ie11/no-weak-collections": [ "error" ]
     }
 }
 ```
 
 ## Supported Rules
 
+* no-array-from: Array.from is not implemented
 * no-collection-args: Map and Set constructors does not accept arguments.
 * no-for-in-const: Do not use const in for-in.
 * no-loop-func: So not create functions inside loops.

--- a/lib/rules/no-array-from.js
+++ b/lib/rules/no-array-from.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Map and Set does not support constructor arguments
+ * @author Morgan Roderick
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Array.from is not implemented",
+            category: "Fill me in",
+            recommended: false
+        },
+        fixable: null,  // or "code" or "whitespace"
+        schema: [
+            // fill in your schema
+        ]
+    },
+
+    create: function(context) {
+
+        // variables should be defined here
+
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        // any helper functions should go here or else delete this section
+
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+            'CallExpression[callee.object.name=Array][callee.property.name=from]': function( node ) {
+                context.report(node, 'Array.from is not implemented (IE11 compatibility)');
+            }
+        };
+    }
+};

--- a/tests/lib/rules/no-array-from.js
+++ b/tests/lib/rules/no-array-from.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Array.from is not supported
+ * @author Morgan Roderick
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-array-from");
+const { RuleTester } = require("eslint");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const { DEFAULT_OPTIONS } = require("../utils");
+
+const valid = [];
+const invalid = [
+  {
+    code: "function hello(){ const args = Array.from(arguments); }",
+    errors: [
+      {
+        message: "Array.from is not implemented (IE11 compatibility)"
+      }
+    ]
+  }
+];
+
+const ruleTester = new RuleTester(DEFAULT_OPTIONS);
+ruleTester.run("no-array-from", rule, { valid, invalid });


### PR DESCRIPTION
This PR adds a new rule `no-array-from`, which will cause errors when trying to use `Array.from` in IE11.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from

The changes here is for a feature from ES2015 that is **missing** from IE11, not just **incorrect** like using collection arguments with `Set` and `Map`.

Are you interested in these kind of contributions to this plugin?